### PR TITLE
Application create

### DIFF
--- a/app/controllers/applications_controller.rb
+++ b/app/controllers/applications_controller.rb
@@ -4,4 +4,21 @@ class ApplicationsController < ApplicationController
     @application = Application.find(params[:id])
     @pets = @application.pets
   end
+
+  def new
+
+  end
+
+  def create
+    application = Application.create!(
+      name: params[:name],
+      street_address: params[:street_address],
+      city: params[:city],
+      state: params[:state],
+      zipcode: params[:zipcode],
+      reason_for_adoption: params[:reason_for_adoption],
+      status: "In Progress"
+    )
+    redirect_to "/applications/#{application.id}"
+  end
 end

--- a/app/controllers/applications_controller.rb
+++ b/app/controllers/applications_controller.rb
@@ -10,7 +10,7 @@ class ApplicationsController < ApplicationController
   end
 
   def create
-    application = Application.create!(
+    application = Application.new(
       name: params[:name],
       street_address: params[:street_address],
       city: params[:city],
@@ -19,6 +19,27 @@ class ApplicationsController < ApplicationController
       reason_for_adoption: params[:reason_for_adoption],
       status: "In Progress"
     )
-    redirect_to "/applications/#{application.id}"
+    # sort out strong_params later; would (app_params, status: "In Progress") work?
+    
+    if application.save
+      redirect_to "/applications/#{application.id}"
+    else
+      redirect_to "/applications/new"
+      flash[:alert] = "Error: #{error_message(application.errors)}"
+    end
+
+    # errors is a built in ActiveModel method
+    # generates an object like #<ActiveModel::Errors [#<ActiveModel::Error attribute=name, type=blank, options={}>]>
+    # then calling .full_messages on this object will return an error message in plain English like "Name can't be blank"
   end
+
+  # Multiple ways to raise an error:
+  # flash.alert
+  # flast[:alert]
+  # redirect_to "path here", notice: "error message"
+
+  # error code is saved in application controller (original)
+  # def error_message(errors)
+  #   errors.full_messages.join(', ')
+  # end
 end

--- a/app/models/application.rb
+++ b/app/models/application.rb
@@ -1,4 +1,11 @@
 class Application < ApplicationRecord
+    validates :name, presence: true
+    validates :street_address, presence: true
+    validates :city, presence: true
+    validates :state, presence: true
+    validates :zipcode, presence: true
+    validates :reason_for_adoption, presence: true
+    
     has_many :pet_applications
     has_many :pets, through: :pet_applications
 end

--- a/app/views/applications/new.html.erb
+++ b/app/views/applications/new.html.erb
@@ -1,0 +1,23 @@
+<h1>Please fill out your information below</h1>
+
+<%= form_with url: "/applications", method: :post, local: true do |form| %>
+  <%= form.label :name %>
+  <%= form.text_field :name %><br>
+
+  <%= form.label :street_address %>
+  <%= form.text_field :street_address %><br>
+
+  <%= form.label :city %>
+  <%= form.text_field :city %><br>
+
+  <%= form.label :state %>
+  <%= form.text_field :state %><br>
+
+  <%= form.label :zipcode %>
+  <%= form.text_field :zipcode %><br>
+
+  <%= form.label :reason_for_adoption, "Please explain why you would be a good home" %>
+  <%= form.text_area :reason_for_adoption %><br>
+
+  <%= form.submit "Submit" %>
+<% end %>

--- a/app/views/pets/index.html.erb
+++ b/app/views/pets/index.html.erb
@@ -1,4 +1,5 @@
 <h1>All pets</h1>
+<%= link_to "Start an Application", "/applications/new" %>
 
 <%= form_with url: "/pets", method: :get, local: true do |f| %>
   <%= f.label :search %>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -37,5 +37,7 @@ Rails.application.routes.draw do
   get "/veterinary_offices/:veterinary_office_id/veterinarians/new", to: "veterinarians#new"
   post "/veterinary_offices/:veterinary_office_id/veterinarians", to: "veterinarians#create"
 
+  get "/applications/new", to: "applications#new"
   get "/applications/:id", to: "applications#show"
+  post "/applications", to: "applications#create"
 end

--- a/spec/features/applications/create_spec.rb
+++ b/spec/features/applications/create_spec.rb
@@ -61,4 +61,111 @@ RSpec.describe "Application Creation" do
     expect(page).to have_content("I work from home and will be around all day to offer companionship")
     expect(page).to have_content("In Progress")
   end
+
+  # As a visitor
+  # When I visit the new application page
+  # And I fail to fill in any of the form fields
+  # And I click submit
+  # Then I am taken back to the new applications page
+  # And I see a message that I must fill in those fields.
+
+  it "should raise error if user doesn't fill out name" do
+    visit "/applications/new"
+
+    fill_in(:street_address, with: "253 Doggie Lane")
+    fill_in(:city, with: "Kitty City")
+    fill_in(:state, with: "WA")
+    fill_in(:zipcode, with: "35467")
+    fill_in(:reason_for_adoption, with: "I work from home and will be around all day to offer companionship")
+    click_button("Submit")
+
+    expect(current_path).to eq("/applications/new")
+    expect(page).to have_content("Error: Name can't be blank")
+  end
+
+  it "should raise error if user doesn't fill out address" do
+    visit "/applications/new"
+
+    fill_in(:name, with: "Jennifer")
+    fill_in(:city, with: "Kitty City")
+    fill_in(:state, with: "WA")
+    fill_in(:zipcode, with: "35467")
+    fill_in(:reason_for_adoption, with: "I work from home and will be around all day to offer companionship")
+    click_button("Submit")
+
+    expect(current_path).to eq("/applications/new")
+    expect(page).to have_content("Error: Street address can't be blank")
+  end
+
+  it "should raise error if user doesn't fill out city" do
+    visit "/applications/new"
+
+    fill_in(:name, with: "Jennifer")
+    fill_in(:street_address, with: "253 Doggie Lane")
+    fill_in(:state, with: "WA")
+    fill_in(:zipcode, with: "35467")
+    fill_in(:reason_for_adoption, with: "I work from home and will be around all day to offer companionship")
+    click_button("Submit")
+
+    expect(current_path).to eq("/applications/new")
+    expect(page).to have_content("Error: City can't be blank")
+  end
+
+  it "should raise error if user doesn't fill out state" do
+    visit "/applications/new"
+
+    fill_in(:name, with: "Jennifer")
+    fill_in(:street_address, with: "253 Doggie Lane")
+    fill_in(:city, with: "Kitty City")
+    fill_in(:zipcode, with: "35467")
+    fill_in(:reason_for_adoption, with: "I work from home and will be around all day to offer companionship")
+    click_button("Submit")
+
+    expect(current_path).to eq("/applications/new")
+    expect(page).to have_content("Error: State can't be blank")
+    #remake the form with a dropdown?
+  end
+
+  it "should raise error if user doesn't fill out zipcode" do
+    visit "/applications/new"
+
+    fill_in(:name, with: "Jennifer")
+    fill_in(:street_address, with: "253 Doggie Lane")
+    fill_in(:city, with: "Kitty City")
+    fill_in(:state, with: "WA")
+    fill_in(:reason_for_adoption, with: "I work from home and will be around all day to offer companionship")
+    click_button("Submit")
+
+    expect(current_path).to eq("/applications/new")
+    expect(page).to have_content("Error: Zipcode can't be blank")
+  end
+
+  it "should raise error if user doesn't fill out reason for adoption" do
+    visit "/applications/new"
+
+    fill_in(:name, with: "Jennifer")
+    fill_in(:street_address, with: "253 Doggie Lane")
+    fill_in(:city, with: "Kitty City")
+    fill_in(:state, with: "WA")
+    fill_in(:zipcode, with: "35467")
+    click_button("Submit")
+
+    expect(current_path).to eq("/applications/new")
+    expect(page).to have_content("Error: Reason for adoption can't be blank")
+  end
+
+  it "may have multiple errors" do
+    visit "/applications/new"
+
+    fill_in(:name, with: "Jennifer")
+    fill_in(:state, with: "WA")
+    fill_in(:zipcode, with: "35467")
+    click_button("Submit")
+
+    expect(current_path).to eq("/applications/new")
+    expect(page).to have_content("Error: Street address can't be blank, City can't be blank, Reason for adoption can't be blank")
+  end
+
+  #edge case- check that zip code is a 5-digit number
+  # validate that street address contains a number?
 end

--- a/spec/features/applications/create_spec.rb
+++ b/spec/features/applications/create_spec.rb
@@ -1,0 +1,64 @@
+require "rails_helper"
+
+RSpec.describe "Application Creation" do
+  
+# As a visitor
+# When I visit the pet index page
+# Then I see a link to "Start an Application"
+  it "is linked to from the pet index page" do
+    visit "/pets"
+
+    expect(page).to have_link("Start an Application", href: "/applications/new")
+  end
+
+# When I click this link
+# Then I am taken to the new application page where I see a form
+  it "has a form to create a new application" do
+    visit "/pets"
+    click_link("Start an Application")
+
+    expect(page).to have_content("Please fill out your information below")
+    expect(page).to have_field(:name)
+    expect(page).to have_field(:street_address)
+    expect(page).to have_field(:city)
+    expect(page).to have_field(:state)
+    expect(page).to have_field(:zipcode)
+    expect(page).to have_content("Please explain why you would be a good home")
+    expect(page).to have_field(:reason_for_adoption)
+    expect(page).to have_button("Submit")
+  end
+
+# When I fill in this form with my:
+#   - Name
+#   - Street Address
+#   - City
+#   - State
+#   - Zip Code
+#   - Description of why I would make a good home
+# And I click submit
+# Then I am taken to the new application's show page
+# And I see my Name, address information, and description of why I would make a good home
+# And I see an indicator that this application is "In Progress"
+  it "can generate a new application and redirect to show page" do
+    visit "/applications/new"
+
+    fill_in(:name, with: "Jennifer")
+    fill_in(:street_address, with: "253 Doggie Lane")
+    fill_in(:city, with: "Kitty City")
+    fill_in(:state, with: "WA")
+    fill_in(:zipcode, with: "35467")
+    fill_in(:reason_for_adoption, with: "I work from home and will be around all day to offer companionship")
+    click_button("Submit")
+
+    app = Application.last
+
+    expect(current_path).to eq("/applications/#{app.id}")
+    expect(page).to have_content("Jennifer")
+    expect(page).to have_content("253 Doggie Lane")
+    expect(page).to have_content("Kitty City")
+    expect(page).to have_content("WA")
+    expect(page).to have_content("35467")
+    expect(page).to have_content("I work from home and will be around all day to offer companionship")
+    expect(page).to have_content("In Progress")
+  end
+end

--- a/spec/features/applications/show_spec.rb
+++ b/spec/features/applications/show_spec.rb
@@ -27,6 +27,5 @@ RSpec.describe "Application Show Page" do
         expect(page).to have_link("Copper", href: "/pets/#{@copper.id}")
         expect(page).to have_link("Willow", href: "/pets/#{@willow.id}")
         expect(page).to have_content("Pending")
-        save_and_open_page
     end
 end


### PR DESCRIPTION
Make a create_spec to test the functionality for a user to create a new application

Test for: link to new application exists from pet index page

form has all expected inputs as text fields
- However, may consider changing the state field to a dropdown?
- Would need to figure out where the save a list of state abbreviates to import it into the form view

Create standard error messages and check that form cannot be submitted with blank fields

Notes regarding the error messages functionality have been left in for your reference as well